### PR TITLE
Remove redundant `wheel` dependency from pyproject.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This package provides the C-API of RapidFuzz. It can be used inside the `pyproje
 
 ```toml
 [build-system]
-requires = ["wheel", "setuptools", "rapidfuzz_capi==1.0.5"]
+requires = ["setuptools", "rapidfuzz_capi==1.0.5"]
 ```
 
 Similar to numpy the include path can be found in the following way:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [build-system]
 requires = [
     "setuptools",
-    "wheel"
 ]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Remove the redundant `wheel` dependency from pyproject.toml.  All
setuptools version automatically expose the dependency via the PEP517
backend since day one.  Listing it explicitly in build requirements
was a documentation mistake that was fixed in:
https://github.com/pypa/setuptools/commit/f7d30a9529378cf69054b5176249e5457aaf640a